### PR TITLE
Remove jupyterhub temporarily

### DIFF
--- a/app-registry.yaml
+++ b/app-registry.yaml
@@ -229,8 +229,6 @@ apps:
                     install_template: terminalman
                   rstudio:
                     install_template: rstudio
-                  jupyterhub:
-                    install_template: jupyter
 
           cloudlaunch:
              image:
@@ -1409,8 +1407,6 @@ apps:
                     install_template: terminalman
                   rstudio:
                     install_template: rstudio
-                  jupyterhub:
-                    install_template: jupyter
           helmsman_config:
             repositories:
                - name: cloudve


### PR DESCRIPTION
Chart changes cause jupyterhub to crash loop on startup.